### PR TITLE
Improve mobile error guidance and messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,10 @@ You can edit/expand **Charities** and **ValueGuide_Custom** at any time — the 
 - **Buttons are disabled after I click.**  
   That’s expected briefly during submission to prevent accidental double-submits. They’ll re-enable automatically after the request finishes.
 
-- **I want to keep the web app private.**  
+- **I want to keep the web app private.**
   When deploying, set **Who has access** to **Only myself** (you’ll need to be signed in to use it).
+- **“Sorry, unable to open the file at this time.” on Safari/Brave**
+  This usually means the browser is blocking Google sign-in or the web app is deployed without **Execute as: Me** + **Anyone with the link**. Make sure you’re signed in to Google in that browser (third-party cookies enabled) and redeploy with the recommended settings, then reload the URL.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -212,10 +212,16 @@ function recalcSum(){
 function loadData(){
   // Charities
   google.script.run
-    .withFailureHandler(err => { console.log("listCharities error:", err); })
+    .withFailureHandler(err => {
+      console.log("listCharities error:", err);
+      toast("Can't load charities. Check sheet access & sign-in.");
+    })
     .withSuccessHandler(res => {
       const payload = res || {ok:false, data:[]};
-      if (payload.ok === false) console.log("listCharities failed:", payload.error||"");
+      if (payload.ok === false) {
+        console.log("listCharities failed:", payload.error||"");
+        toast("Charity list unavailable. Confirm SHEET_ID & sharing.");
+      }
       charities = payload.data || [];
       const sel1 = document.getElementById('cashOrg');
       const sel2 = document.getElementById('itemsOrg');
@@ -235,10 +241,16 @@ function loadData(){
 
   // Items for global datalist
   google.script.run
-    .withFailureHandler(err => { console.log("listItems error:", err); })
+    .withFailureHandler(err => {
+      console.log("listItems error:", err);
+      toast("Can't load value guide. Check sheet access & sign-in.");
+    })
     .withSuccessHandler(res => {
       const payload = res || {ok:false, data:[]};
-      if (payload.ok === false) console.log("listItems failed:", payload.error||"");
+      if (payload.ok === false) {
+        console.log("listItems failed:", payload.error||"");
+        toast("Value guide unavailable. Confirm SHEET_ID & sharing.");
+      }
       items = payload.data || [];
       const dl = document.getElementById('items-dl'); dl.innerHTML = "";
       items.forEach(it => { const o=document.createElement('option'); o.value = it.item; dl.appendChild(o); });


### PR DESCRIPTION
## Summary
- surface toasts when the app cannot load charities or the value guide so users know to check sharing/sign-in
- document Safari/Brave "Sorry, unable to open the file" troubleshooting guidance in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f8dfdde1f8832a8df5bacabed8bb65