### PR TITLE
Add printout report generation and UI trigger

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -135,3 +135,98 @@ function submitItems(payload) {
     throw new Error("Failed to submit items: " + e.toString());
   }
 }
+
+function buildPrintout() {
+  const ss = _ss();
+  const dataSheet = ss.getSheetByName(SHEET_LOG);
+  if (!dataSheet) throw new Error(`Sheet "${SHEET_LOG}" not found.`);
+
+  let rpt = ss.getSheetByName('Printout');
+  if (!rpt) rpt = ss.insertSheet('Printout');
+  rpt.clear();
+  rpt.setHiddenGridlines(true);
+
+  rpt.setColumnWidths(1, 1, 28);
+  rpt.setColumnWidths(2, 1, 36);
+  rpt.setColumnWidths(3, 1, 65);
+  rpt.setColumnWidths(4, 1, 16);
+
+  const year = new Date().getFullYear();
+  const name = ss.getOwner() ? ss.getOwner().getEmail() : 'YOUR NAME';
+
+  rpt.getRange('A1:D1').merge().setValue(`${year} Tax Year`).setFontSize(16).setFontWeight('bold').setHorizontalAlignment('center');
+  rpt.getRange('A2:D2').merge().setValue('YTD Charitable Deductions').setFontSize(14).setFontWeight('bold').setHorizontalAlignment('center');
+  rpt.getRange('A3:D3').merge().setValue(name).setFontSize(12).setFontWeight('bold').setHorizontalAlignment('center');
+
+  let row = 5;
+
+  const values = dataSheet.getDataRange().getValues();
+  const headers = values.shift();
+  const idx = Object.fromEntries(headers.map((h,i)=>[h,i]));
+
+  function isCash(r){ return String(r[idx['IRS Donation Type Classification']] || '').toLowerCase().includes('cash'); }
+  function isNonCash(r){ return String(r[idx['IRS Donation Type Classification']] || '').toLowerCase().includes('non'); }
+
+  function fmtDateForReport(d){
+    if (!(d instanceof Date)) return d;
+    return Utilities.formatDate(d, ss.getSpreadsheetTimeZone(), 'yyyy-MM-dd');
+  }
+
+  function writeSection(title, filterFn) {
+    rpt.getRange(row,1,1,4).merge().setValue(title).setFontWeight('bold');
+    row++;
+
+    rpt.getRange(row,1).setValue('Charity Name / Donated Date').setFontWeight('bold');
+    rpt.getRange(row,2).setValue('Charity Address').setFontWeight('bold');
+    rpt.getRange(row,3).setValue('Donation Description').setFontWeight('bold');
+    rpt.getRange(row,4).setValue('Donation Amount').setFontWeight('bold').setHorizontalAlignment('right');
+    row++;
+
+    const rows = values.filter(filterFn).sort((a,b)=>{
+      const ca = String(a[idx['Charity']]||'');
+      const cb = String(b[idx['Charity']]||'');
+      if (ca !== cb) return ca.localeCompare(cb);
+      return new Date(a[idx['Date']]) - new Date(b[idx['Date']]);
+    });
+
+    let total = 0;
+
+    rows.forEach(r=>{
+      const charity = r[idx['Charity']] || '';
+      const addr = r[idx['Charity Address']] || '';
+      const date = fmtDateForReport(r[idx['Date']]);
+      const desc = r[idx['Description']] || '';
+      const amt = Number(r[idx['Donation Value in $']] || 0);
+
+      rpt.getRange(row,1).setValue(`${charity}\n${date}`).setWrap(true);
+      rpt.getRange(row,2).setValue(addr).setWrap(true);
+      rpt.getRange(row,3).setValue(desc).setWrap(true);
+      rpt.getRange(row,4).setValue(amt).setNumberFormat('$#,##0.00').setHorizontalAlignment('right');
+
+      total += amt;
+      row++;
+    });
+
+    rpt.getRange(row,3).setValue('Subtotal :').setFontWeight('bold').setHorizontalAlignment('right');
+    rpt.getRange(row,4).setValue(total).setNumberFormat('$#,##0.00').setFontWeight('bold').setHorizontalAlignment('right');
+    row++;
+
+    return total;
+  }
+
+  const nonCashTotal = writeSection('Non-Cash Donations', isNonCash);
+  rpt.getRange(row,3).setValue('Total Non-Cash Donations:').setFontWeight('bold').setHorizontalAlignment('right');
+  rpt.getRange(row,4).setValue(nonCashTotal).setNumberFormat('$#,##0.00').setFontWeight('bold').setHorizontalAlignment('right');
+  row += 2;
+
+  const cashTotal = writeSection('Cash Donations', isCash);
+  rpt.getRange(row,3).setValue('Total Cash Donations:').setFontWeight('bold').setHorizontalAlignment('right');
+  rpt.getRange(row,4).setValue(cashTotal).setNumberFormat('$#,##0.00').setFontWeight('bold').setHorizontalAlignment('right');
+  row += 2;
+
+  rpt.getRange(row,3).setValue('Grand Total:').setFontWeight('bold').setHorizontalAlignment('right');
+  rpt.getRange(row,4).setValue(nonCashTotal + cashTotal).setNumberFormat('$#,##0.00').setFontWeight('bold').setHorizontalAlignment('right');
+
+  rpt.getRange(6,1,row,4).setVerticalAlignment('top');
+  rpt.getDataRange().setFontFamily('Arial').setFontSize(10);
+}

--- a/index.html
+++ b/index.html
@@ -166,6 +166,7 @@
     <div class="actions">
       <button class="btn-ghost" onclick="addRow()">+ Add item</button>
       <button id="btnItems" class="btn-primary" onclick="submitItems()">Submit Items</button>
+      <button class="btn-ghost" onclick="generatePrintout()">Generate Printout</button>
     </div>
   </div>
 </div>
@@ -633,6 +634,17 @@ async function submitItems(){
   } finally {
       // 4. This runs no matter what (success or error), ONLY after the above are done
       lock(btn, false);
+  }
+}
+
+async function generatePrintout(){
+  if (!confirm("Generate the printout sheet now?")) return;
+
+  try {
+    await runServer('buildPrintout');
+    toast("Printout sheet generated");
+  } catch (err) {
+    toast("Error: " + err);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Provide a one-click way to build a printable year-to-date donations report from the donations log sheet.
- Generate a consolidated printout that separates cash and non-cash donations and computes subtotals and a grand total for tax reporting.
- Keep the report generation server-side so it can be run from the Web App UI without manual sheet manipulation.

### Description
- Added a new server function `buildPrintout()` in `Code.gs` that creates/clears a `Printout` sheet, lays out columns, headers, and formatted rows, and computes subtotals and a grand total.
- `buildPrintout()` reads the donations data from the `SHEET_LOG` sheet, indexes headers, filters rows by `IRS Donation Type Classification`, sorts by charity and date, and formats currency and dates for the report.
- Wired a UI button in `index.html` labeled "Generate Printout" and added a client handler `generatePrintout()` that calls the server via `runServer('buildPrintout')` and shows a toast on completion.
- Formatting and layout touches include column widths, merged title rows, bolded headers, number formatting using `setNumberFormat`, and Arial font for the printout.

### Testing
- No automated tests were run because this change requires the Apps Script runtime and a Google Sheet environment to execute.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ab34dc494832aba544fb65da1ec3e)