### PR TITLE
Fix printout misclassification and incorporate date fixes from #15

### DIFF
--- a/index.html
+++ b/index.html
@@ -497,9 +497,13 @@ async function loadCharities(selectedCharity) {
       });
     }
     
-    const today = new Date().toISOString().slice(0,10);
-    document.getElementById('cashDate').value = today;
-    document.getElementById('itemsDate').value = today;
+    const today = new Date();
+    const dd = String(today.getDate()).padStart(2, '0');
+    const mm = String(today.getMonth() + 1).padStart(2, '0');
+    const yyyy = today.getFullYear();
+    const date = `${yyyy}-${mm}-${dd}`;
+    document.getElementById('cashDate').value = date;
+    document.getElementById('itemsDate').value = date;
     
     return true; // Signals completion
   } catch (err) {
@@ -516,13 +520,13 @@ async function submitCash(){
 
   const org     = document.getElementById('cashOrg').value.trim();
   const newOrg  = document.getElementById('cashNewOrg').value.trim();
-  const dateISO = document.getElementById('cashDate').value;
+  const date    = document.getElementById('cashDate').value;
   const amount  = Number(document.getElementById('cashAmount').value || 0);
   const method  = document.getElementById('cashMethod').value;
   const note    = document.getElementById('cashNote').value.trim();
 
   if (!org && !newOrg) { toast("Pick an organization or enter a new one."); return; }
-  if (!dateISO)        { toast("Please choose a date."); return; }
+  if (!date)           { toast("Please choose a date."); return; }
   if (!(amount > 0))   { toast("Amount must be > 0."); return; }
   if (!confirm(`Submit cash: $${amount.toFixed(2)}?`)) return;
 
@@ -530,7 +534,7 @@ async function submitCash(){
     org,
     newOrg,
     newAddr: document.getElementById('cashNewAddr').value,
-    dateISO,
+    date,
     amount,
     method,
     note
@@ -566,10 +570,10 @@ async function submitItems(){
 
   const org     = document.getElementById('itemsOrg').value.trim();
   const newOrg  = document.getElementById('itemsNewOrg').value.trim();
-  const dateISO = document.getElementById('itemsDate').value;
+  const date    = document.getElementById('itemsDate').value;
 
   if (!org && !newOrg) { toast("Pick an organization or enter a new one."); return; }
-  if (!dateISO)        { toast("Please choose a date."); return; }
+  if (!date)           { toast("Please choose a date."); return; }
 
   const rows = [...document.getElementById('itemsList').children];
   
@@ -607,7 +611,7 @@ async function submitItems(){
     org,
     newOrg,
     newAddr: document.getElementById('itemsNewAddr').value,
-    dateISO,
+    date,
     lines: lines.filter(l => l.item && (l.lineTotal > 0 || l.override > 0))
   };
 


### PR DESCRIPTION
## Summary

Fixes `buildPrintout()` misclassifying donations: it checked `IRS Donation Type Classification` for "cash"/"non" substrings, but that column actually holds the payment method (cash gifts) or item condition (goods), so Credit Card donations and every item donation were silently dropped from the generated printout. Now classifies via `Donation Type === "Money"`, builds a real per-row description, and looks up charity addresses from the `Charities` sheet (the log never stored them).

Also incorporates #15 (@chadcancode's date fixes): the default date shown in the UI used `toISOString()` (UTC), which could show tomorrow's date for users behind UTC; and `fmtDate()` parsed a plain `YYYY-MM-DD` string through `new Date()` plus timezone conversion, which could shift the logged date by one day. Both now avoid UTC/timezone conversion entirely.

#15 has been open since January without maintainer activity, so its unmodified commit is folded into this PR along with the printout fix so both land together.

## Test plan

Verified the printout fix live against the production sheet: previously only 1 of 9 real donations appeared in the generated report (Credit Card entries were dropped); after the fix all 9 appear with correct addresses and descriptions.

Verified the date fix live: default date field now shows the correct local date instead of drifting to the next day.

Confirmed the merged file parses and runs cleanly in the Apps Script editor (no syntax errors) before deploying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)